### PR TITLE
Make test suite pass under python3.5

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,5 +1,5 @@
 # Don't use the --user flag for setup.py develop mode with virtualenv.
-DEV_USER_FLAG=$(shell python2 -c "import sys; print('' if hasattr(sys, 'real_prefix') else '--user')")
+DEV_USER_FLAG=$(shell python3 -c "import sys; print('' if hasattr(sys, 'real_prefix') else '--user')")
 
 .PHONY: default
 default: dev

--- a/lib/roi_data/loader.py
+++ b/lib/roi_data/loader.py
@@ -79,7 +79,7 @@ class RoIDataLoader(object):
         # When training with N > 1 GPUs, each element in the minibatch queue
         # is actually a partial minibatch which contributes 1 / N of the
         # examples to the overall minibatch
-        self._minibatch_queue = Queue.Queue(maxsize=minibatch_queue_size)
+        self._minibatch_queue = Queue(maxsize=minibatch_queue_size)
         self._blobs_queue_capacity = blobs_queue_capacity
         # Random queue name in case one instantiates multple RoIDataLoaders
         self._loader_id = uuid.uuid4()

--- a/lib/utils/io.py
+++ b/lib/utils/io.py
@@ -45,7 +45,7 @@ def cache_url(url_or_file, cache_dir):
     path to the cached file. If the argument is not a URL, simply return it as
     is.
     """
-    is_url = re.match(r'^(?:http)s?://', url_or_file, re.IGNORECASE) is not None
+    is_url = re.match(rb'^(?:http)s?://', url_or_file, re.IGNORECASE) is not None
 
     if not is_url:
         return url_or_file

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -83,7 +83,7 @@ class TestCfg(unittest.TestCase):
             core.config.merge_cfg_from_cfg(cfg2)
 
     def test_merge_cfg_from_file(self):
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(mode="w") as f:
             yaml.dump(cfg, f)
             s = cfg.MODEL.TYPE
             cfg.MODEL.TYPE = 'dummy'
@@ -123,7 +123,7 @@ class TestCfg(unittest.TestCase):
     def test_deprecated_key_from_file(self):
         # You should see logger messages like:
         #   "Deprecated config key (ignoring): MODEL.DILATION"
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(mode="w") as f:
             cfg2 = copy.deepcopy(cfg)
             cfg2.MODEL.DILATION = 2
             yaml.dump(cfg2, f)
@@ -147,7 +147,7 @@ class TestCfg(unittest.TestCase):
         # You should see logger messages like:
         #  "Key EXAMPLE.RENAMED.KEY was renamed to EXAMPLE.KEY;
         #  please update your config"
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile("w") as f:
             cfg2 = copy.deepcopy(cfg)
             cfg2.EXAMPLE = AttrDict()
             cfg2.EXAMPLE.RENAMED = AttrDict()


### PR DESCRIPTION
Tests run:

```
for t in tests/*.py; do python3 ${t}; done
```